### PR TITLE
Youtube extension

### DIFF
--- a/wiki/conf/LocalSettings.php
+++ b/wiki/conf/LocalSettings.php
@@ -156,7 +156,12 @@ require_once "$IP/skins/Vector/Vector.php";
 require_once "$IP/extensions/MobileFrontend/MobileFrontend.php";
 $wgMFAutodetectMobileView = true;
 
+# Enable WYSIWYG editor extension
 require_once "$IP/extensions/VisualEditor/VisualEditor.php";
+
+# Enable YouTube extension
+wfLoadExtension( 'YouTube' );
+
 // Enable by default for everybody
 $wgDefaultUserOptions['visualeditor-enable'] = 1;
 // Don't allow users to disable it

--- a/wiki/docker-mediawiki/Dockerfile
+++ b/wiki/docker-mediawiki/Dockerfile
@@ -46,6 +46,9 @@ RUN curl -o MobileFrontend.tgz https://extdist.wmflabs.org/dist/extensions/Mobil
 RUN curl -o visualeditor.tgz https://extdist.wmflabs.org/dist/extensions/VisualEditor-REL1_27-9da5996.tar.gz \
     && tar -zxf visualeditor.tgz -C /usr/src/mediawiki/extensions
 
+RUN curl -o youtube.tgz https://extdist.wmflabs.org/dist/extensions/YouTube-REL1_27-555d66a.tar.gz \
+    && tar -zxf youtube.tgz -C /usr/src/mediawiki/extensions
+
 COPY apache/mediawiki.conf /etc/apache2/
 RUN echo Include /etc/apache2/mediawiki.conf >> /etc/apache2/apache2.conf
 


### PR DESCRIPTION
I have added this extension so that I can re-create the 'About' page from the wordpress site, onto our Mediawiki. I would like to include their embedded youtube video on that page. This extension adds that capability while still not allowing other raw HTML